### PR TITLE
Implement capability to decode tenant domain from id token

### DIFF
--- a/oidc-js/src/constants/token.ts
+++ b/oidc-js/src/constants/token.ts
@@ -29,5 +29,6 @@ export const SCOPE = "scope";
 export const SESSION_STATE = "session_state";
 export const TOKEN_TYPE = "token_type";
 export const REQUEST_PARAMS = "request_params";
+export const TENANT_DOMAIN = "tenant_domain";
 export const ISSUER = "issuer";
 export const LOGOUT_URL = "logout_url";

--- a/oidc-js/src/models/authenticated-user.ts
+++ b/oidc-js/src/models/authenticated-user.ts
@@ -20,7 +20,29 @@
  * Interface of the authenticated user.
  */
 export interface AuthenticatedUserInterface {
+    /**
+     * Authenticated user's display name.
+     */
     displayName?: string;
+    /**
+     * Authenticated user's display name.
+     * @deprecated Use `displayName` instead.
+     */
+    display_name?: string;
+    /**
+     * User's email.
+     */
     email?: string;
+    /**
+     * Available scopes. 
+     */
+    scope?: string;
+    /**
+     * Authenticated user's tenant domain.
+     */
+    tenantDomain?: string;
+    /**
+     * Authenticated user's username.
+     */
     username: string;
 }

--- a/oidc-js/src/models/message.ts
+++ b/oidc-js/src/models/message.ts
@@ -64,6 +64,7 @@ export interface UserInfo {
     username: string;
     displayName: string;
     allowedScopes: string;
+    tenantDomain: string;
 }
 
 export interface UserInfoWorker extends UserInfo {

--- a/oidc-js/src/models/session.ts
+++ b/oidc-js/src/models/session.ts
@@ -22,6 +22,4 @@ import { TokenResponseInterface } from "./token-response";
 /**
  * Interface of the user session.
  */
-export interface SessionInterface extends AuthenticatedUserInterface, TokenResponseInterface {
-
-}
+export interface SessionInterface extends Omit<AuthenticatedUserInterface, "scope">, TokenResponseInterface { }

--- a/oidc-js/src/models/token-response.ts
+++ b/oidc-js/src/models/token-response.ts
@@ -58,6 +58,10 @@ export interface StrictDecodedIdTokenPayloadInterface {
      * Name by which the user wishes to be referred to.
      */
     preferred_username?: string;
+    /**
+     * The tenant domain of the user to whom the ID token belongs.
+     */
+    tenant_domain?: string;
 }
 
 export interface DecodedIdTokenPayloadInterface extends StrictDecodedIdTokenPayloadInterface {

--- a/oidc-js/src/public-api.ts
+++ b/oidc-js/src/public-api.ts
@@ -14,11 +14,15 @@
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
 
-import "core-js/stable";
-import "regenerator-runtime/runtime";
+/**
+ * Entry point for all public APIs of this SDK.
+ */
+export * from "./client";
+export * from "./models";
 
-// Export the public API.
-export * from "./public-api";
+// Constants
+export * from "./constants/endpoints";
+export * from "./constants/storage";
+export * from "./constants/hooks";

--- a/oidc-js/src/utils/index.ts
+++ b/oidc-js/src/utils/index.ts
@@ -22,3 +22,4 @@ export * from "./op-config";
 export * from "./session-storage";
 export * from "./sign-in";
 export * from "./sign-out";
+export * from "./token";

--- a/oidc-js/src/utils/op-config.ts
+++ b/oidc-js/src/utils/op-config.ts
@@ -28,12 +28,12 @@ import {
     OP_CONFIG_INITIATED,
     REVOKE_TOKEN_ENDPOINT,
     SERVICE_RESOURCES,
-    SIGN_IN_REDIRECT_URL,
-    SIGN_OUT_REDIRECT_URL,
     Storage,
     TENANT,
     TOKEN_ENDPOINT,
-    USERNAME
+    USERNAME,
+    SIGN_IN_REDIRECT_URL,
+    SIGN_OUT_REDIRECT_URL
 } from "../constants";
 import { ConfigInterface, ServiceResourcesType, WebWorkerConfigInterface } from "../models";
 

--- a/oidc-js/src/utils/op-config.ts
+++ b/oidc-js/src/utils/op-config.ts
@@ -28,12 +28,12 @@ import {
     OP_CONFIG_INITIATED,
     REVOKE_TOKEN_ENDPOINT,
     SERVICE_RESOURCES,
+    SIGN_IN_REDIRECT_URL,
+    SIGN_OUT_REDIRECT_URL,
     Storage,
     TENANT,
     TOKEN_ENDPOINT,
-    USERNAME,
-    SIGN_IN_REDIRECT_URL,
-    SIGN_OUT_REDIRECT_URL
+    USERNAME
 } from "../constants";
 import { ConfigInterface, ServiceResourcesType, WebWorkerConfigInterface } from "../models";
 

--- a/oidc-js/src/utils/session-storage.ts
+++ b/oidc-js/src/utils/session-storage.ts
@@ -29,6 +29,7 @@ import {
     REQUEST_PARAMS,
     SCOPE,
     Storage,
+    TENANT_DOMAIN,
     TOKEN_TYPE,
     USERNAME
 } from "../constants";
@@ -126,6 +127,7 @@ export function endAuthenticatedSession(requestParams: ConfigInterface | WebWork
     removeSessionParameter(ID_TOKEN, requestParams);
     removeSessionParameter(REFRESH_TOKEN, requestParams);
     removeSessionParameter(SCOPE, requestParams);
+    removeSessionParameter(TENANT_DOMAIN, requestParams);
     removeSessionParameter(TOKEN_TYPE, requestParams);
     removeSessionParameter(USERNAME, requestParams);
 }
@@ -150,6 +152,7 @@ export function initUserSession(
     setSessionParameter(ID_TOKEN, tokenResponse.idToken, requestParams);
     setSessionParameter(SCOPE, tokenResponse.scope, requestParams);
     setSessionParameter(REFRESH_TOKEN, tokenResponse.refreshToken, requestParams);
+    setSessionParameter(TENANT_DOMAIN, authenticatedUser.tenantDomain, requestParams);
     setSessionParameter(TOKEN_TYPE, tokenResponse.tokenType, requestParams);
     setSessionParameter(USERNAME, authenticatedUser.username, requestParams);
 }
@@ -168,6 +171,7 @@ export function getAllSessionParameters(requestParams: ConfigInterface | WebWork
         idToken: getSessionParameter(ID_TOKEN, requestParams),
         refreshToken: getSessionParameter(REFRESH_TOKEN, requestParams),
         scope: getSessionParameter(SCOPE, requestParams),
+        tenantDomain: getSessionParameter(TENANT_DOMAIN, requestParams),
         tokenType: getSessionParameter(TOKEN_TYPE, requestParams),
         username: getSessionParameter(USERNAME, requestParams)
     };

--- a/oidc-js/src/utils/sign-in.ts
+++ b/oidc-js/src/utils/sign-in.ts
@@ -35,6 +35,7 @@ import {
     removeSessionParameter,
     setSessionParameter
 } from "./session-storage";
+import { getTenantDomainFromIdTokenPayload } from "./token";
 import {
     ACCESS_TOKEN,
     AUTHORIZATION_CODE,
@@ -52,13 +53,15 @@ import {
     SERVICE_RESOURCES,
     SESSION_STATE,
     SIGNED_IN,
+    Storage,
+    TENANT_DOMAIN,
     TOKEN_ENDPOINT,
     TOKEN_TAG,
     USERNAME,
     USERNAME_TAG
 } from "../constants";
-import { Storage } from "../constants/storage";
 import {
+    AuthenticatedUserInterface,
     ConfigInterface,
     CustomGrantRequestParams,
     DecodedIdTokenPayloadInterface,
@@ -69,8 +72,6 @@ import {
     WebWorkerConfigInterface,
     isWebWorkerConfig
 } from "../models";
-import { AuthenticatedUserInterface } from "../models/authenticated-user";
-
 
 /**
  * Checks whether authorization code is present.
@@ -107,7 +108,7 @@ export function getAuthorizationCode(requestParams?: ConfigInterface | WebWorker
  * Get token request headers.
  *
  * @param {string} clientHost
- * @returns {{Accept: string; "Access-Control-Allow-Origin": string; "Content-Type": string}}
+ * @returns {TokenRequestHeader}
  */
 export const getTokenRequestHeaders = (clientHost: string): TokenRequestHeader => {
     return {
@@ -441,12 +442,14 @@ export function sendRevokeTokenRequest(
  * @returns {AuthenticatedUserInterface} authenticated user.
  */
 export const getAuthenticatedUser = (idToken: string): AuthenticatedUserInterface => {
-    const payload = JSON.parse(atob(idToken.split(".")[1]));
-    const emailAddress = payload.email ? payload.email : null;
+    const payload: DecodedIdTokenPayloadInterface = JSON.parse(atob(idToken.split(".")[1]));
+    const emailAddress: string = payload.email ? payload.email : null;
+    const tenantDomain: string = getTenantDomainFromIdTokenPayload(payload);
 
     return {
         displayName: payload.preferred_username ? payload.preferred_username : payload.sub,
         email: emailAddress,
+        tenantDomain,
         username: payload.sub
     };
 };
@@ -512,9 +515,9 @@ export function handleSignIn(requestParams: ConfigInterface | WebWorkerConfigInt
  * Replaces template tags with actual values.
  *
  * @param {string} text Input string.
- * @param {string} scope Scope.
+ * @param {ConfigInterface | WebWorkerConfigInterface} authConfig - Auth config object.
  *
- * @returns String with template tags replaced with actual values.
+ * @return {string} String with template tags replaced with actual values.
  */
 const replaceTemplateTags = (
     text: string,
@@ -540,8 +543,8 @@ const replaceTemplateTags = (
 /**
  * Allows using custom grant types.
  *
- * @param {CustomGrantRequestParams} requestParams The request parameters.
- *
+ * @param {CustomGrantRequestParams} requestParams - The request parameters.
+ * @param {ConfigInterface | WebWorkerConfigInterface} authConfig - Auth config object.
  * @returns {Promise<boolean|AxiosResponse>} A promise that resolves with a boolean value or the request response
  * if the the `returnResponse` attribute in the `requestParams` object is set to `true`.
  */
@@ -659,6 +662,7 @@ export const getUserInfo = (config: ConfigInterface | WebWorkerConfigInterface):
         allowedScopes: getSessionParameter(SCOPE, config),
         displayName: getSessionParameter(DISPLAY_NAME, config),
         email: getSessionParameter(EMAIL, config),
+        tenantDomain: getSessionParameter(TENANT_DOMAIN, config),
         username: getSessionParameter(USERNAME, config)
     };
 };

--- a/oidc-js/src/utils/token.ts
+++ b/oidc-js/src/utils/token.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { DecodedIdTokenPayloadInterface } from "../models";
+
+/**
+ * Extracts the tenant domain from the ID token payload.
+ *
+ * @param {DecodedIdTokenPayloadInterface} payload - Decoded ID token payload.
+ * @param {string} uidSeparator - Separator to split the uid.
+ * @return {string} Extracted tenant domain.
+ */
+export const getTenantDomainFromIdTokenPayload = (payload: DecodedIdTokenPayloadInterface,
+                                                  uidSeparator: string = "@"): string => {
+
+    // If the `tenant_domain` claim is available in the ID token payload, give precedence.
+    if (payload.tenant_domain) {
+        return payload.tenant_domain;
+    }
+
+    // Try to extract the tenant domain from the `sub` claim.
+    const uid = payload.sub;
+    const tokens = uid.split(uidSeparator);
+
+    return tokens[ tokens.length - 1 ];
+};

--- a/oidc-js/src/worker/web-worker-client.ts
+++ b/oidc-js/src/worker/web-worker-client.ts
@@ -30,7 +30,6 @@ import {
     GET_USER_INFO,
     INIT,
     LOGOUT,
-    LOGOUT_URL,
     PKCE_CODE_VERIFIER,
     REQUEST_ERROR,
     REQUEST_FINISH,
@@ -38,7 +37,8 @@ import {
     REQUEST_SUCCESS,
     SESSION_STATE,
     SIGNED_IN,
-    SIGN_IN
+    SIGN_IN,
+    LOGOUT_URL
 } from "../constants";
 import {
     AuthCode,
@@ -49,11 +49,11 @@ import {
     ResponseMessage,
     ServiceResourcesType,
     SignInResponse,
-    SignInResponseWorker,
     UserInfo,
     WebWorkerClientInterface,
     WebWorkerConfigInterface,
-    WebWorkerSingletonClientInterface
+    WebWorkerSingletonClientInterface,
+    SignInResponseWorker
 } from "../models";
 import { getAuthorizationCode } from "../utils";
 
@@ -249,9 +249,9 @@ export const WebWorkerClient: WebWorkerSingletonClientInterface = (function(): W
      * Send multiple API requests to the web worker and returns the response.
      * Similar `axios.spread` in functionality.
      *
-     * @param {AxiosRequestConfig[]} config The Axios Request Config object
+     * @param {AxiosRequestConfig[]} configs - The Axios Request Config object
      *
-     * @returns {Promise<AxiosResponse>[]} A promise that resolves with the response data.
+     * @returns {Promise<AxiosResponse<T>[]>} A promise that resolves with the response data.
      */
     const httpRequestAll = <T = any>(configs: AxiosRequestConfig[]): Promise<AxiosResponse<T>[]> => {
         if (!initialized) {
@@ -507,6 +507,7 @@ export const WebWorkerClient: WebWorkerSingletonClientInterface = (function(): W
                                 allowedScopes: "",
                                 displayName: "",
                                 email: "",
+                                tenantDomain: "",
                                 username: ""
                             });
                         } else {
@@ -662,7 +663,7 @@ export const WebWorkerClient: WebWorkerSingletonClientInterface = (function(): W
      *
      * This returns the object containing the public methods.
      *
-     * @returns {OAuthInterface} OAuthInterface object
+     * @returns {WebWorkerClientInterface} OAuthInterface object
      */
     function Constructor(): WebWorkerClientInterface {
         worker = new WorkerFile();

--- a/oidc-js/src/worker/web-worker-client.ts
+++ b/oidc-js/src/worker/web-worker-client.ts
@@ -457,6 +457,7 @@ export const WebWorkerClient: WebWorkerSingletonClientInterface = (function(): W
                         allowedScopes: "",
                         displayName: "",
                         email: "",
+                        tenantDomain: "",
                         username: ""
                     });
                 }

--- a/oidc-js/src/worker/web-worker-client.ts
+++ b/oidc-js/src/worker/web-worker-client.ts
@@ -30,6 +30,7 @@ import {
     GET_USER_INFO,
     INIT,
     LOGOUT,
+    LOGOUT_URL,
     PKCE_CODE_VERIFIER,
     REQUEST_ERROR,
     REQUEST_FINISH,
@@ -37,8 +38,7 @@ import {
     REQUEST_SUCCESS,
     SESSION_STATE,
     SIGNED_IN,
-    SIGN_IN,
-    LOGOUT_URL
+    SIGN_IN
 } from "../constants";
 import {
     AuthCode,
@@ -49,11 +49,11 @@ import {
     ResponseMessage,
     ServiceResourcesType,
     SignInResponse,
+    SignInResponseWorker,
     UserInfo,
     WebWorkerClientInterface,
     WebWorkerConfigInterface,
-    WebWorkerSingletonClientInterface,
-    SignInResponseWorker
+    WebWorkerSingletonClientInterface
 } from "../models";
 import { getAuthorizationCode } from "../utils";
 

--- a/oidc-js/src/worker/web-worker.ts
+++ b/oidc-js/src/worker/web-worker.ts
@@ -23,14 +23,15 @@ import {
     AUTHORIZATION_ENDPOINT,
     DISPLAY_NAME,
     EMAIL,
-    ID_TOKEN,
     OIDC_SESSION_IFRAME_ENDPOINT,
     PKCE_CODE_VERIFIER,
     SCOPE,
     SESSION_STATE,
     SIGNED_IN,
-    SIGN_OUT_REDIRECT_URL,
-    USERNAME
+    TENANT_DOMAIN,
+    USERNAME,
+    ID_TOKEN,
+    SIGN_OUT_REDIRECT_URL
 } from "../constants";
 import { AxiosHttpClient, AxiosHttpClientInstance } from "../http-client";
 import {
@@ -39,12 +40,12 @@ import {
     ServiceResourcesType,
     SessionData,
     SignInResponse,
-    SignInResponseWorker,
     UserInfo,
     WebWorkerClientConfigInterface,
     WebWorkerConfigInterface,
     WebWorkerInterface,
-    WebWorkerSingletonInterface
+    WebWorkerSingletonInterface,
+    SignInResponseWorker
 } from "../models";
 import {
     customGrant as customGrantUtil,
@@ -133,6 +134,7 @@ export const WebWorker: WebWorkerSingletonInterface = (function (): WebWorkerSin
                             email: session.get(EMAIL),
                             logoutUrl: logoutCallback,
                             oidcSessionIframe: session.get(OIDC_SESSION_IFRAME_ENDPOINT),
+                            tenantDomain: session.get(TENANT_DOMAIN),
                             username: session.get(USERNAME)
                         },
                         type: response.type
@@ -183,7 +185,9 @@ export const WebWorker: WebWorkerSingletonInterface = (function (): WebWorkerSin
     /**
      * Saves the passed authorization code on the session
      *
-     * @param {string} authCode The authorization code.
+     * @param {string} authCode - The authorization code.
+     * @param {string} sessionState - Session state.
+     * @param {string} pkce - PKCE code.
      */
     const setAuthCode = (authCode: string, sessionState: string, pkce: string): void => {
         authCode && session.set(AUTHORIZATION_CODE, authCode);
@@ -239,7 +243,7 @@ export const WebWorker: WebWorkerSingletonInterface = (function (): WebWorkerSin
     /**
      * Makes multiple api calls. Wraps `axios.spread`.
      *
-     * @param {AxiosRequestConfig[]} config API request data.
+     * @param {AxiosRequestConfig[]} configs - API request data.
      *
      * @returns {AxiosResponse[]} A promise that resolves with the response.
      */
@@ -299,11 +303,11 @@ export const WebWorker: WebWorkerSingletonInterface = (function (): WebWorkerSin
 
     const getServiceEndpoints = (): Promise<ServiceResourcesType> => {
         return Promise.resolve(getServiceEndpointsUtil(authConfig));
-    }
+    };
 
     const getDecodedIDToken = (): DecodedIdTokenPayloadInterface => {
         return getDecodedIDTokenUtil(authConfig);
-    }
+    };
 
     /**
      * @constructor
@@ -312,7 +316,7 @@ export const WebWorker: WebWorkerSingletonInterface = (function (): WebWorkerSin
      *
      * @param {ConfigInterface} config Configuration data.
      *
-     * @returns {OAuthWorkerInterface} Returns the object containing
+     * @returns {WebWorkerInterface} Returns the object containing
      */
     function Constructor(config: WebWorkerClientConfigInterface): WebWorkerInterface {
         authConfig = { ...config };

--- a/oidc-js/src/worker/web-worker.ts
+++ b/oidc-js/src/worker/web-worker.ts
@@ -23,15 +23,15 @@ import {
     AUTHORIZATION_ENDPOINT,
     DISPLAY_NAME,
     EMAIL,
+    ID_TOKEN,
     OIDC_SESSION_IFRAME_ENDPOINT,
     PKCE_CODE_VERIFIER,
     SCOPE,
     SESSION_STATE,
     SIGNED_IN,
+    SIGN_OUT_REDIRECT_URL,
     TENANT_DOMAIN,
-    USERNAME,
-    ID_TOKEN,
-    SIGN_OUT_REDIRECT_URL
+    USERNAME
 } from "../constants";
 import { AxiosHttpClient, AxiosHttpClientInstance } from "../http-client";
 import {
@@ -40,12 +40,12 @@ import {
     ServiceResourcesType,
     SessionData,
     SignInResponse,
+    SignInResponseWorker,
     UserInfo,
     WebWorkerClientConfigInterface,
     WebWorkerConfigInterface,
     WebWorkerInterface,
-    WebWorkerSingletonInterface,
-    SignInResponseWorker
+    WebWorkerSingletonInterface
 } from "../models";
 import {
     customGrant as customGrantUtil,


### PR DESCRIPTION
## Purpose
If the tenant domain is available in the `sub`(uid) claim of the ID token, it can decoded and added to the authenticated user's detail response.

## Goals
This PR adds changes to decode the tenant domain from the ID token.

## Approach
Split the `sub` and extract the tenant domain.

**Regular usernames**

```
brion@wso2.com -> wso2.com
``` 

**Email usernames**

```
brion@gmail.com@wso2.com -> wso2.com
``` 