### PR TITLE
Implement getDecodedIDToken method and allow id token validation to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ The `end-user-session` hook is used to fire a callback function after end user s
 This method returns an object containing the OIDC endpoints obtained from the `.well-known` endpoint.
 
 ### getDecodedIDToken
-This method returns teh decoded payload of the JWT ID token.
+This method returns the decoded payload of the JWT ID token.
 
 ### on
 The `on` method is used to hook callback functions to authentication methods. The method accepts a hook name and a callback function as the only arguments except when the hook name is "custom-grant", in which case the id of the custom grant should be passed as the third argument. The following hooks are available.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ This method takes a `config` object as the only argument. The attributes of the 
 |`endpoints` (optional)|[`ServiceResourceTypes`](#serviceresourcetypes)|[ServiceResource Default Values](#serviceresourcetypes)| The OIDC endpoint URLs. The SDK will try to obtain the endpoint URLS using the `.well-known` endpoint. If this fails, the SDK will use these endpoint URLs. If this attribute is not set, then the default endpoint URLs will be used.|
 |`authorizationCode` (optional)| `string`|""|When the `responseMode` is set to `from_post`, the authorization code is returned as a `POST` request. Apps can use this attribute to pass the obtained authorization code to the SDK. Since client applications can't handle `POST` requests, the application's backend should implement the logic to receive the authorization code and send it back to the SDK.|
 | `sessionState` (optional) | `string`|""| When the `responseMode` is set to `from_post`, the session state is returned as a `POST` request. Apps can use this attribute to pass the obtained session state to the SDK. Since client applications can't handle `POST` requests, the application's backend should implement the logic to receive the session state and send it back to the SDK.|
+|`validateIDToken`(optional)|`boolean`|`true`|Allows you to enable/disable JWT ID token validation after obtaining the ID token.|
 
 The `initialize` hook is used to fire a callback function after initializing is successful. Check the [on()](#on) section for more information.
 ### Storage

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ The backend can then inject the authorization code into a JavaSCript variable wh
 
 To address this issue, we recommend storing the authorization code in a server session variable and providing the Single Page Application a separate API endpoint to request the authorization code. The server, when the request is received, can then respond with the authorization code from the server session.
 
-![form_post auth code flow](https://github.com/asgardio/asgardio-js-oidc-sdk/blob/master/img/auth_code.png)
+![form_post auth code flow](https://raw.githubusercontent.com/asgardio/asgardio-js-oidc-sdk/master/img/auth_code.png)
 
 You can refer to a sample implementation using JSP [here](/samples/java-webapp).
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
         - [The data Attribute](#the-data-attribute)
     - [endUserSession](#endusersession)
     - [getServiceEndpoints](#getserviceendpoints)
+    - [getDecodedIDToken](#getdecodedidtoken)
 - [Using the `form_post` Response Mode](#using-the-form_post-response-mode)
 - [Develop](#develop)
     - [Prerequisites](#prerequisites)
@@ -136,7 +137,7 @@ This method takes a `config` object as the only argument. The attributes of the 
 |`scope` (optional)|`string[]`|`["openid"]`|Specifies the requested scopes|
 |`serverOrigin`|`string`|""|The origin of the Identity Provider. eg: `https://www.asgardio.io`|
 |[`storage`](#storage) (optional)| `"sessionStorage"`, `"webWorker"`, `"localStorage"`|`"sessionStorage"`| The storage medium where the session information such as the access token should be stored.|
-|`baseUrls` (required if the `storage` is set to `webWorker`|`string[]`|""|The URLs of the API endpoints.|
+|`baseUrls` (required if the `storage` is set to `webWorker`|`string[]`|""|The URLs of the API endpoints. This is needed only if the storage method is set to `webWorker`. When API calls are made through the [`httpRequest`](#httprequest) or the [`httpRequestAll`](#httprequestall) method, only the calls to the endpoints specified in the `baseURL` attribute will be allowed. Everything else will be denied.|
 |`endpoints` (optional)|[`ServiceResourceTypes`](#serviceresourcetypes)|[ServiceResource Default Values](#serviceresourcetypes)| The OIDC endpoint URLs. The SDK will try to obtain the endpoint URLS using the `.well-known` endpoint. If this fails, the SDK will use these endpoint URLs. If this attribute is not set, then the default endpoint URLs will be used.|
 |`authorizationCode` (optional)| `string`|""|When the `responseMode` is set to `from_post`, the authorization code is returned as a `POST` request. Apps can use this attribute to pass the obtained authorization code to the SDK. Since client applications can't handle `POST` requests, the application's backend should implement the logic to receive the authorization code and send it back to the SDK.|
 | `sessionState` (optional) | `string`|""| When the `responseMode` is set to `from_post`, the session state is returned as a `POST` request. Apps can use this attribute to pass the obtained session state to the SDK. Since client applications can't handle `POST` requests, the application's backend should implement the logic to receive the session state and send it back to the SDK.|
@@ -290,6 +291,9 @@ The `end-user-session` hook is used to fire a callback function after end user s
 
 ### getServiceEndpoints
 This method returns an object containing the OIDC endpoints obtained from the `.well-known` endpoint.
+
+### getDecodedIDToken
+This method returns teh decoded payload of the JWT ID token.
 
 ### on
 The `on` method is used to hook callback functions to authentication methods. The method accepts a hook name and a callback function as the only arguments except when the hook name is "custom-grant", in which case the id of the custom grant should be passed as the third argument. The following hooks are available.

--- a/oidc-js/src/client.ts
+++ b/oidc-js/src/client.ts
@@ -52,7 +52,8 @@ const DefaultConfig = {
     consentDenied: false,
     enablePKCE: true,
     responseMode: null,
-    scope: [OIDC_SCOPE]
+    scope: [ OIDC_SCOPE ],
+    validateIDToken: true
 };
 
 /**
@@ -128,7 +129,7 @@ export class IdentityClient {
             this._client = WebWorkerClient.getInstance();
 
             return this._client
-                .initialize(config)
+                .initialize({ ...DefaultConfig, ...config })
                 .then(() => {
                     if (this._onInitialize) {
                         this._onInitialize(true);

--- a/oidc-js/src/client.ts
+++ b/oidc-js/src/client.ts
@@ -22,15 +22,17 @@ import { AxiosHttpClient, AxiosHttpClientInstance } from "./http-client";
 import {
     ConfigInterface,
     CustomGrantRequestParams,
+    DecodedIdTokenPayloadInterface,
+    isWebWorkerConfig,
     ServiceResourcesType,
     UserInfo,
     WebWorkerClientInterface,
-    WebWorkerConfigInterface,
-    isWebWorkerConfig
+    WebWorkerConfigInterface
 } from "./models";
 import {
     customGrant as customGrantUtil,
     endAuthenticatedSession,
+    getDecodedIDToken,
     getServiceEndpoints,
     getSessionParameter,
     getUserInfo as getUserInfoUtil,
@@ -350,6 +352,14 @@ export class IdentityClient {
         }
 
         throw Error("Identity Client has not been initialized yet");
+    }
+
+    public getDecodedIDToken(): Promise<DecodedIdTokenPayloadInterface>{
+        if (this._storage === Storage.WebWorker) {
+            return this._client.getDecodedIDToken();
+        }
+
+        return Promise.resolve(getDecodedIDToken(this._authConfig));
     }
 
     public on(hook: Hooks.CustomGrant, callback: (response?: any) => void, id: string): void;

--- a/oidc-js/src/client.ts
+++ b/oidc-js/src/client.ts
@@ -23,11 +23,11 @@ import {
     ConfigInterface,
     CustomGrantRequestParams,
     DecodedIdTokenPayloadInterface,
-    isWebWorkerConfig,
     ServiceResourcesType,
     UserInfo,
     WebWorkerClientInterface,
-    WebWorkerConfigInterface
+    WebWorkerConfigInterface,
+    isWebWorkerConfig
 } from "./models";
 import {
     customGrant as customGrantUtil,

--- a/oidc-js/src/constants/messages.ts
+++ b/oidc-js/src/constants/messages.ts
@@ -33,3 +33,4 @@ export const REQUEST_ERROR = "request-error";
 export const REQUEST_FINISH = "request-finish";
 export const GET_SERVICE_ENDPOINTS = "get-service-endpoints";
 export const GET_USER_INFO = "get-user-info";
+export const GET_DECODED_ID_TOKEN = "get-decoded-id-token";

--- a/oidc-js/src/models/client.ts
+++ b/oidc-js/src/models/client.ts
@@ -38,6 +38,7 @@ interface BaseConfigInterface {
     endpoints?: ServiceResourcesType;
     authorizationCode?: string;
     sessionState?: string;
+    validateIDToken?: boolean;
 }
 /**
  * SDK Client config parameters.

--- a/oidc-js/src/models/index.ts
+++ b/oidc-js/src/models/index.ts
@@ -26,3 +26,4 @@ export * from "./web-worker-client";
 export * from "./web-worker";
 export * from "./session";
 export * from "./endpoints";
+export * from "./token-response";

--- a/oidc-js/src/models/message.ts
+++ b/oidc-js/src/models/message.ts
@@ -23,6 +23,7 @@ import {
     AUTH_REQUIRED,
     CUSTOM_GRANT,
     END_USER_SESSION,
+    GET_DECODED_ID_TOKEN,
     GET_SERVICE_ENDPOINTS,
     GET_USER_INFO,
     INIT,
@@ -90,4 +91,5 @@ export type MessageType =
     | typeof REQUEST_START
     | typeof REQUEST_SUCCESS
     | typeof GET_SERVICE_ENDPOINTS
-    | typeof GET_USER_INFO;
+    | typeof GET_USER_INFO
+    | typeof GET_DECODED_ID_TOKEN;

--- a/oidc-js/src/models/token-response.ts
+++ b/oidc-js/src/models/token-response.ts
@@ -59,10 +59,6 @@ export interface DecodedIdTokenPayloadInterface {
      */
     preferred_username?: string;
     /**
-     * The tenant domain of the user to whom the ID token belongs.
-     */
-    tenant_domain?: string;
-    /**
      * Other custom claims;
      */
     [ any: string ]: any;

--- a/oidc-js/src/models/token-response.ts
+++ b/oidc-js/src/models/token-response.ts
@@ -33,3 +33,37 @@ export interface TokenRequestHeader {
     "Access-Control-Allow-Origin": string;
     "Content-Type": string;
 }
+
+/**
+ * Interface for the payload of a Decoded ID Token.
+ */
+export interface DecodedIdTokenPayloadInterface {
+    /**
+     * The audience for which this token is intended.
+     */
+    aud: string | string[];
+    /**
+     * The uid corresponding to the user who the ID token belonged to.
+     */
+    sub: string;
+    /**
+     * The issuer identifier for the issuer of the response.
+     */
+    iss: string;
+    /**
+     * The email of the user to whom the ID token belongs.
+     */
+    email?: string;
+    /**
+     * Name by which the user wishes to be referred to.
+     */
+    preferred_username?: string;
+    /**
+     * The tenant domain of the user to whom the ID token belongs.
+     */
+    tenant_domain?: string;
+    /**
+     * Other custom claims;
+     */
+    [ any: string ]: any;
+}

--- a/oidc-js/src/models/token-response.ts
+++ b/oidc-js/src/models/token-response.ts
@@ -37,7 +37,7 @@ export interface TokenRequestHeader {
 /**
  * Interface for the payload of a Decoded ID Token.
  */
-export interface DecodedIdTokenPayloadInterface {
+export interface StrictDecodedIdTokenPayloadInterface {
     /**
      * The audience for which this token is intended.
      */
@@ -58,6 +58,9 @@ export interface DecodedIdTokenPayloadInterface {
      * Name by which the user wishes to be referred to.
      */
     preferred_username?: string;
+}
+
+export interface DecodedIdTokenPayloadInterface extends StrictDecodedIdTokenPayloadInterface {
     /**
      * Other custom claims;
      */

--- a/oidc-js/src/models/web-worker-client.ts
+++ b/oidc-js/src/models/web-worker-client.ts
@@ -20,6 +20,7 @@ import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import { WebWorkerConfigInterface } from ".";
 import { ServiceResourcesType } from "./endpoints";
 import { SignInResponse, UserInfo } from "./message";
+import { DecodedIdTokenPayloadInterface } from "./token-response";
 
 export interface WebWorkerClientInterface {
     httpRequest<T = any>(config: AxiosRequestConfig): Promise<AxiosResponse<T>>;
@@ -37,6 +38,7 @@ export interface WebWorkerClientInterface {
 
     onHttpRequestFinish(callback: () => void): void;
     getUserInfo(): Promise<UserInfo>;
+    getDecodedIDToken(): Promise<DecodedIdTokenPayloadInterface>;
 }
 
 export interface WebWorkerSingletonClientInterface {

--- a/oidc-js/src/models/web-worker.ts
+++ b/oidc-js/src/models/web-worker.ts
@@ -20,6 +20,7 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { WebWorkerClientConfigInterface } from "./client";
 import { ServiceResourcesType } from "./endpoints";
 import { Message, SignInResponse, UserInfo } from "./message";
+import { DecodedIdTokenPayloadInterface } from "./token-response";
 import { CustomGrantRequestParams } from "./web-worker-client";
 
 export interface WebWorkerInterface {
@@ -35,6 +36,7 @@ export interface WebWorkerInterface {
     getUserInfo(): UserInfo;
     endUserSession(): Promise<boolean>;
     getServiceEndpoints(): Promise<ServiceResourcesType>;
+    getDecodedIDToken(): DecodedIdTokenPayloadInterface;
 }
 
 export interface WebWorkerSingletonInterface {

--- a/oidc-js/src/utils/crypto.ts
+++ b/oidc-js/src/utils/crypto.ts
@@ -103,7 +103,6 @@ export const getJWKForTheIdToken = (jwtHeader: string, keys: JWKInterface[]): Er
  * @param {string} issuer id_token issuer.
  * @returns {any} whether the id_token is valid.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export const isValidIdToken = (
     idToken: string,
     jwk: string,

--- a/oidc-js/src/utils/sign-in.ts
+++ b/oidc-js/src/utils/sign-in.ts
@@ -43,6 +43,7 @@ import {
     CLIENT_SECRET_TAG,
     DISPLAY_NAME,
     EMAIL,
+    ID_TOKEN,
     OIDC_SCOPE,
     PKCE_CODE_VERIFIER,
     REQUEST_PARAMS,
@@ -66,7 +67,11 @@ import {
     isWebWorkerConfig
 } from "../models";
 import { AuthenticatedUserInterface } from "../models/authenticated-user";
-import { TokenRequestHeader, TokenResponseInterface } from "../models/token-response";
+import {
+    DecodedIdTokenPayloadInterface,
+    TokenRequestHeader,
+    TokenResponseInterface
+} from "../models/token-response";
 
 /**
  * Checks whether authorization code is present.
@@ -602,4 +607,19 @@ export const getUserInfo = (config: ConfigInterface | WebWorkerConfigInterface):
         email: getSessionParameter(EMAIL, config),
         username: getSessionParameter(USERNAME, config)
     };
+};
+
+/**
+ *
+ * @param {ConfigInterface} config - The configuration parameters.
+ *
+ * @return {DecodedIdTokenPayloadInterface} The decoded ID Token payload.
+ */
+export const getDecodedIDToken = (
+    config: ConfigInterface | WebWorkerConfigInterface
+): DecodedIdTokenPayloadInterface => {
+    const idToken = getSessionParameter(ID_TOKEN, config);
+    const payload: DecodedIdTokenPayloadInterface = JSON.parse(atob(idToken.split(".")[1]));
+
+    return payload;
 };

--- a/oidc-js/src/utils/sign-in.ts
+++ b/oidc-js/src/utils/sign-in.ts
@@ -61,17 +61,16 @@ import { Storage } from "../constants/storage";
 import {
     ConfigInterface,
     CustomGrantRequestParams,
+    DecodedIdTokenPayloadInterface,
     SignInResponse,
+    TokenRequestHeader,
+    TokenResponseInterface,
     UserInfo,
     WebWorkerConfigInterface,
     isWebWorkerConfig
 } from "../models";
 import { AuthenticatedUserInterface } from "../models/authenticated-user";
-import {
-    DecodedIdTokenPayloadInterface,
-    TokenRequestHeader,
-    TokenResponseInterface
-} from "../models/token-response";
+
 
 /**
  * Checks whether authorization code is present.
@@ -369,7 +368,8 @@ export function sendRefreshTokenRequest(
                         return Promise.resolve(tokenResponse);
                     }
 
-                    return Promise.reject(new Error("Invalid id_token in the token response: " + response.data.id_token));
+                    return Promise.reject(
+                        new Error("Invalid id_token in the token response: " + response.data.id_token));
                 });
             } else {
                 const tokenResponse: TokenResponseInterface = {

--- a/oidc-js/src/worker/oidc.worker.ts
+++ b/oidc-js/src/worker/oidc.worker.ts
@@ -24,6 +24,7 @@ import {
     AUTH_REQUIRED,
     CUSTOM_GRANT,
     END_USER_SESSION,
+    GET_DECODED_ID_TOKEN,
     GET_SERVICE_ENDPOINTS,
     GET_USER_INFO,
     INIT,
@@ -242,6 +243,26 @@ ctx.onmessage = ({ data, ports }) => {
 
             try {
                 port.postMessage(generateSuccessDTO(webWorker.getUserInfo()));
+            } catch (error) {
+                port.postMessage(generateFailureDTO(error));
+            }
+
+            break;
+        case GET_DECODED_ID_TOKEN:
+            if (!webWorker) {
+                port.postMessage(generateFailureDTO("Worker has not been initiated."));
+
+                break;
+            }
+
+            if (!webWorker.isSignedIn() && data.data.signInRequired) {
+                port.postMessage(generateFailureDTO("You have not signed in yet."));
+
+                break;
+            }
+
+            try {
+                port.postMessage(generateSuccessDTO(webWorker.getDecodedIDToken()));
             } catch (error) {
                 port.postMessage(generateFailureDTO(error));
             }

--- a/oidc-js/src/worker/web-worker-client.ts
+++ b/oidc-js/src/worker/web-worker-client.ts
@@ -25,6 +25,7 @@ import {
     AUTH_REQUIRED,
     CUSTOM_GRANT,
     END_USER_SESSION,
+    GET_DECODED_ID_TOKEN,
     GET_SERVICE_ENDPOINTS,
     GET_USER_INFO,
     INIT,
@@ -51,7 +52,8 @@ import {
     UserInfo,
     WebWorkerClientInterface,
     WebWorkerConfigInterface,
-    WebWorkerSingletonClientInterface
+    WebWorkerSingletonClientInterface,
+    DecodedIdTokenPayloadInterface
 } from "../models";
 import { getAuthorizationCode } from "../utils";
 
@@ -603,19 +605,33 @@ export const WebWorkerClient: WebWorkerSingletonClientInterface = (function(): W
             });
     };
 
-      const getUserInfo = (): Promise<UserInfo> => {
-          const message: Message<null> = {
-              type: GET_USER_INFO
-          };
+    const getUserInfo = (): Promise<UserInfo> => {
+        const message: Message<null> = {
+            type: GET_USER_INFO
+        };
 
-          return communicate<null, UserInfo>(message)
-              .then((response) => {
-                  return Promise.resolve(response);
-              })
-              .catch((error) => {
-                  return Promise.reject(error);
-              });
-      };
+        return communicate<null, UserInfo>(message)
+            .then((response) => {
+                return Promise.resolve(response);
+            })
+            .catch((error) => {
+                return Promise.reject(error);
+            });
+    };
+
+    const getDecodedIDToken = (): Promise<DecodedIdTokenPayloadInterface> => {
+        const message: Message<null> = {
+            type: GET_DECODED_ID_TOKEN
+        };
+
+        return communicate<null, DecodedIdTokenPayloadInterface>(message)
+            .then((response) => {
+                return Promise.resolve(response);
+            })
+            .catch((error) => {
+                return Promise.reject(error);
+        })
+    }
 
     const onHttpRequestSuccess = (callback: (response: AxiosResponse) => void): void => {
         if (callback && typeof callback === "function") {
@@ -654,6 +670,7 @@ export const WebWorkerClient: WebWorkerSingletonClientInterface = (function(): W
         return {
             customGrant,
             endUserSession,
+            getDecodedIDToken,
             getServiceEndpoints,
             getUserInfo,
             httpRequest,

--- a/oidc-js/src/worker/web-worker-client.ts
+++ b/oidc-js/src/worker/web-worker-client.ts
@@ -443,6 +443,20 @@ export const WebWorkerClient: WebWorkerSingletonClientInterface = (function(): W
                     const data = response.data;
                     delete data.logoutUrl;
                     return Promise.resolve(data);
+                } else if (response.type === AUTH_REQUIRED) {
+
+                    if (response.pkce) {
+                        sessionStorage.setItem(PKCE_CODE_VERIFIER, response.pkce);
+                    }
+
+                    location.href = response.code;
+
+                    return Promise.resolve({
+                        allowedScopes: "",
+                        displayName: "",
+                        email: "",
+                        username: ""
+                    });
                 }
 
                 return Promise.reject(

--- a/oidc-js/src/worker/web-worker.ts
+++ b/oidc-js/src/worker/web-worker.ts
@@ -35,6 +35,7 @@ import {
 import { AxiosHttpClient, AxiosHttpClientInstance } from "../http-client";
 import {
     CustomGrantRequestParams,
+    DecodedIdTokenPayloadInterface,
     ServiceResourcesType,
     SessionData,
     SignInResponse,
@@ -48,6 +49,7 @@ import {
 import {
     customGrant as customGrantUtil,
     endAuthenticatedSession,
+    getDecodedIDToken as getDecodedIDTokenUtil,
     getEndSessionEndpoint,
     getServiceEndpoints as getServiceEndpointsUtil,
     getSessionParameter,
@@ -299,6 +301,10 @@ export const WebWorker: WebWorkerSingletonInterface = (function (): WebWorkerSin
         return Promise.resolve(getServiceEndpointsUtil(authConfig));
     }
 
+    const getDecodedIDToken = (): DecodedIdTokenPayloadInterface => {
+        return getDecodedIDTokenUtil(authConfig);
+    }
+
     /**
      * @constructor
      *
@@ -344,6 +350,7 @@ export const WebWorker: WebWorkerSingletonInterface = (function (): WebWorkerSin
             customGrant,
             doesTokenExist,
             endUserSession,
+            getDecodedIDToken,
             getServiceEndpoints,
             getUserInfo,
             httpRequest,


### PR DESCRIPTION
## Purpose
>  The decoded ID token can now be obtained by using the following method.
```javascript
auth.getDecodedIDToken().then((response)=>{
    // console.log(response);
}).catch((error)=>{
    // console.error(error);
});
```

> ID Token validation can be disabled by setting `validateIDToken` attribute of the `config` object passed as the argument into the `initialize` method to `false`.