### PR TITLE
Fix on sign-out hook not firing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,14 +303,16 @@ The `on` method is used to hook callback functions to authentication methods. Th
 |Hook|Method to which the callback function is attached| Returned Response|
 |:--|:--|:--|
 |`"sign-in"`|`signIn()`| The user information|
-|`"sign-out"`|`signOut()`|
+|`"sign-out"`|`signOut()`||
 |`"initialize"`|`initialize()`|A boolean value indicating if the initialization was successful or not.|
 |`"http-request-start"`| `httpRequest()` (Called before an http request is sent)|
 |`"http-request-finish"`|`httpRequest()` (Called after an http request is sent and response is received.)|
 |`"http-request-error"`| `httpRequest()` (Called when an http request returns an error)|
 |`"http-request-success"`| `httpRequest()` (Called when an http requests returns a response successfully)|
 |`"end-user-session"`| `endUserSession()`| A boolean value indicating if the process was successful or not
-|`"custom-grant"`| `customGrant()`|
+|`"custom-grant"`| `customGrant()`|Returns the response from the custom grant request.
+
+**When the user signs out, the user is taken to the identity server's logout page and then redirected back to the SPA on successful log out. Hence, developers should ensure that the `"sign-out"` hook is called when the page the user is redirected to loads.**
 
 ## Using the `form_post` response mode
 When the `responseMode` is set to `form_post`, the authorization code is sent in the body of a `POST` request as opposed to in the URL. So, the Single Page Application should have a backend to receive the authorization code and send it back to the Single Page Application.

--- a/oidc-js/.eslintrc.js
+++ b/oidc-js/.eslintrc.js
@@ -1,77 +1,73 @@
 module.exports = {
-    extends: [
-        "eslint:recommended",
-        "plugin:import/typescript"
-    ],
+    env: {
+        browser: true,
+        es6: true,
+        jest: true,
+        node: true
+    },
+    extends: ["eslint:recommended", "plugin:import/typescript"],
+    overrides: [{
+        env: {
+            browser: true,
+            es6: true,
+            node: true
+        },
+        extends: [
+            "eslint:recommended",
+            "plugin:@typescript-eslint/eslint-recommended",
+            "plugin:@typescript-eslint/recommended"
+        ],
+        files: ["**/*.tsx", "**/*.ts"],
+        parser: "@typescript-eslint/parser",
+        parserOptions: {
+            ecmaVersion: 9,
+            sourceType: "module"
+        },
+        rules: {
+            "@typescript-eslint/explicit-function-return-type": 0,
+            "@typescript-eslint/no-explicit-any": 0,
+            "@typescript-eslint/no-inferrable-types": "off",
+            "@typescript-eslint/no-use-before-define": ["warn", {
+                classes: false,
+                functions: false,
+                typedefs: false,
+                variables: false
+            }],
+            "eol-last": "error",
+            "no-use-before-define": "off"
+        }
+    }],
     parserOptions: {
         ecmaVersion: 9,
         sourceType: "module"
     },
-    plugins: [ "import" ],
-    env: {
-        browser: true,
-        jest: true,
-        node: true,
-        es6: true
-    },
+    plugins: ["import"],
     rules: {
+        "comma-dangle": ["warn", "never"],
         "eol-last": "error",
-        "quotes": [ "warn", "double" ],
-        "max-len": [ "warn", { "code": 120 } ],
-        "comma-dangle": [ "warn", "never" ],
-        "sort-imports": [ "warn", {
+        "import/order": ["warn", {
+            "alphabetize": {
+                caseInsensitive: true,
+                order: "asc"
+            },
+            "groups": ["builtin", "external", "index", "sibling", "parent", "internal"]
+        }],
+        "max-len": ["warn", {
+            "code": 120
+        }],
+        "no-console": "warn",
+        "no-duplicate-imports": "warn",
+        "object-curly-spacing": ["warn", "always"],
+        "quotes": ["warn", "double"],
+        "sort-imports": ["warn", {
             "ignoreCase": false,
             "ignoreDeclarationSort": true,
             "ignoreMemberSort": false
-        } ],
-        "import/order": [
-            "warn",
-            {
-                "groups": [ "builtin", "external", "index", "sibling", "parent", "internal" ],
-                "alphabetize": {
-                    order: "asc",
-                    caseInsensitive: true
-                }
-            }
-        ],
-        "sort-keys": [ "warn", "asc", { "caseSensitive": true, "natural": false, "minKeys": 2 } ],
-        "object-curly-spacing": [ "warn", "always" ],
-        "no-console": "warn",
-        "no-duplicate-imports": "warn"    },
-    overrides: [
-        {
-            files: [ "**/*.tsx", "**/*.ts" ],
-            parser: "@typescript-eslint/parser",
-            extends: [
-                "eslint:recommended",
-                "plugin:@typescript-eslint/eslint-recommended",
-                "plugin:@typescript-eslint/recommended"
-            ],
-            parserOptions: {
-                ecmaVersion: 9,
-                sourceType: "module"
-            },
-            env: {
-                browser: true,
-                node: true,
-                es6: true
-            },
-            rules: {
-                "eol-last": "error",
-                "@typescript-eslint/no-explicit-any": 0,
-                "@typescript-eslint/explicit-function-return-type": 0,
-                "@typescript-eslint/no-inferrable-types": "off",
-                "no-use-before-define": "off",
-                "@typescript-eslint/no-use-before-define": [
-                    "warn",
-                    {
-                        functions: false,
-                        classes: false,
-                        variables: false,
-                        typedefs: false
-                    }
-                ]
-            }
-        }
-    ]
+        }],
+        "sort-keys": ["warn", "asc", {
+            "caseSensitive": true,
+            "minKeys": 2,
+            "natural": false
+        }]
+    }
 };

--- a/oidc-js/src/client.ts
+++ b/oidc-js/src/client.ts
@@ -38,9 +38,9 @@ import {
     getUserInfo as getUserInfoUtil,
     handleSignIn,
     handleSignOut,
+    isLoggedOut,
     resetOPConfiguration,
-    sendRevokeTokenRequest,
-    isLoggedOut
+    sendRevokeTokenRequest
 } from "./utils";
 import { WebWorkerClient } from "./worker";
 

--- a/oidc-js/src/client.ts
+++ b/oidc-js/src/client.ts
@@ -39,7 +39,8 @@ import {
     handleSignIn,
     handleSignOut,
     resetOPConfiguration,
-    sendRevokeTokenRequest
+    sendRevokeTokenRequest,
+    isLoggedOut
 } from "./utils";
 import { WebWorkerClient } from "./worker";
 
@@ -229,9 +230,6 @@ export class IdentityClient {
             return this._client
                 .signOut()
                 .then((response) => {
-                    if (this._onSignOutCallback) {
-                        this._onSignOutCallback(response);
-                    }
 
                     return Promise.resolve(response);
                 })
@@ -242,9 +240,6 @@ export class IdentityClient {
 
         return handleSignOut(this._authConfig)
             .then((response) => {
-                if (this._onSignOutCallback) {
-                    this._onSignOutCallback(response);
-                }
 
                 return Promise.resolve(response);
             })
@@ -384,6 +379,9 @@ export class IdentityClient {
                     break;
                 case Hooks.SignOut:
                     this._onSignOutCallback = callback;
+                    if (isLoggedOut()) {
+                        callback();
+                    }
                     break;
                 case Hooks.EndUserSession:
                     this._onEndUserSession = callback;

--- a/oidc-js/src/constants/messages.ts
+++ b/oidc-js/src/constants/messages.ts
@@ -34,3 +34,4 @@ export const REQUEST_FINISH = "request-finish";
 export const GET_SERVICE_ENDPOINTS = "get-service-endpoints";
 export const GET_USER_INFO = "get-user-info";
 export const GET_DECODED_ID_TOKEN = "get-decoded-id-token";
+export const LOGOUT_SUCCESS = "logout_success";

--- a/oidc-js/src/worker/web-worker-client.ts
+++ b/oidc-js/src/worker/web-worker-client.ts
@@ -43,6 +43,7 @@ import {
 import {
     AuthCode,
     CustomGrantRequestParams,
+    DecodedIdTokenPayloadInterface,
     HttpClient,
     Message,
     ResponseMessage,
@@ -52,8 +53,7 @@ import {
     UserInfo,
     WebWorkerClientInterface,
     WebWorkerConfigInterface,
-    WebWorkerSingletonClientInterface,
-    DecodedIdTokenPayloadInterface
+    WebWorkerSingletonClientInterface
 } from "../models";
 import { getAuthorizationCode } from "../utils";
 

--- a/samples/react-js-app/src/components/dashboard.tsx
+++ b/samples/react-js-app/src/components/dashboard.tsx
@@ -16,10 +16,10 @@
  * under the License.
  */
 
-import React, { ReactElement, FunctionComponent, useState } from "react";
+import React, { ReactElement, FunctionComponent, useState, useEffect } from "react";
 import { SIGN_OUT, SIGN_IN } from "../constants";
 import { useHistory } from "react-router-dom";
-import { IdentityClient } from '@asgardio/oidc-js';
+import { IdentityClient, Hooks } from '@asgardio/oidc-js';
 import { useRecoilState } from "recoil";
 import { authState, displayName } from "../recoil";
 
@@ -35,11 +35,38 @@ export const Dashboard: FunctionComponent<null> = (): ReactElement => {
 
     const [ isAuth ] = useRecoilState(authState);
     const [ displayNameState ] = useRecoilState(displayName);
+    const [ isLoggedOut, setIsLoggedOut ] = useState(false);
+
+    useEffect(() => {
+        auth.on(Hooks.SignOut, () => {
+            setIsLoggedOut(true);
+        });
+    }, [auth]);
 
     return <div className="wrapper">
         <div className="menu">
-            <button onClick={ () => { history.push(SIGN_IN); } }>Sign In</button>
-            <button onClick={ () => { history.push(SIGN_OUT); } }>Sign Out</button>
+            <button onClick={ () => {
+                if (isAuth) {
+                    alert("You have already signed in!");
+                } else {
+                    setIsLoggedOut(false);
+                    history.push(SIGN_IN);
+                }
+            } }>
+                Sign In
+            </button>
+
+            <button onClick={ () => {
+                if (isAuth) {
+                    history.push(SIGN_OUT);
+                } else {
+                    alert("You haven't signed in!");
+                }
+            }
+            }>
+                Sign Out
+            </button>
+
             <button onClick={ () => {
                 if (isAuth) {
                     auth.httpRequest({
@@ -60,8 +87,8 @@ export const Dashboard: FunctionComponent<null> = (): ReactElement => {
             } }>Get user info</button>
         </div>
         <div id="greeting">
-
             { isAuth && "Hi, " + displayNameState + "!" }
+            { isLoggedOut && "You have logged out!" }
         </div>
         <div className="details">
             <div id="email">

--- a/samples/react-js-app/src/components/sign-out.tsx
+++ b/samples/react-js-app/src/components/sign-out.tsx
@@ -17,8 +17,7 @@
  */
 
 import { ReactElement, FunctionComponent, useEffect } from "react";
-import { IdentityClient, Hooks } from "@asgardio/oidc-js";
-import { DASHBOARD } from "../constants";
+import { IdentityClient } from "@asgardio/oidc-js";
 import { useHistory } from "react-router-dom";
 
 export const SignOut: FunctionComponent<null> = (): ReactElement => {
@@ -27,9 +26,7 @@ export const SignOut: FunctionComponent<null> = (): ReactElement => {
 
     useEffect(() => {
         const auth = IdentityClient.getInstance();
-        auth.on(Hooks.SignOut, () => {
-            history.push(DASHBOARD);
-        });
+
         auth.signOut();
     }, [history]);
 


### PR DESCRIPTION
## Purpose
> When the `signOut` method is called, the user is redirected to the identity server's page and redirected back to the SPA after successfully logging out. Since on redirection, the SPA is reloaded fresh, the `sign-out` hook wasn't calling the callback function.

## Solution
> The `state` param of the logout URL is used to know if the SPA is being loaded after a logout. If it is so, then the `sign-out` hook's callback gets called. 