### PR TITLE
Prevent on sign in hook getting called when auth code request is obtained

### DIFF
--- a/oidc-js/src/client.ts
+++ b/oidc-js/src/client.ts
@@ -193,8 +193,6 @@ export class IdentityClient {
                     if (this._onSignInCallback) {
                         if (response.allowedScopes || response.displayName || response.email || response.username) {
                             this._onSignInCallback(response);
-                        } else {
-                            this._onSignInCallback(null);
                         }
                     }
 


### PR DESCRIPTION
Prevent on sign in hook getting called when auth code request is obtained