### PR TITLE
Set origin as the default value of clientHost 

### DIFF
--- a/packages/oidc-js/README.md
+++ b/packages/oidc-js/README.md
@@ -205,16 +205,16 @@ This method takes a `config` object as the only argument. The attributes of the 
 
 |Attribute| Type | Default Value| Description|
 |:-----|:----|:----|:----|
-|`signInRedirectURL`|`string`||The URL to redirect to after the user authorizes the client app. eg: `https://conotoso.com/login` |
-|`signOutRedirectURL`|`string`||The URL to redirect to after the user signs out. eg: `https://conotoso.com/logout` |
-|`clientHost`|`string`||The hostname of the client app.  eg: `https://contoso.com`|
-|`clientID`| `string` ||The client ID of the OIDC application hosted in the Asgardio.
+|`signInRedirectURL`|`string`|""|The URL to redirect to after the user authorizes the client app. eg: `https://conotoso.com/login` |
+|`clientID`| `string` |""|The client ID of the OIDC application hosted in the Asgardio.|
+|`serverOrigin`|`string`|""|The origin of the Identity Provider. eg: `https://www.asgardio.io`|
+|`signOutRedirectURL` (optional)|`string`|`signInRedirectURL` |The URL to redirect to after the user signs out. eg: `https://conotoso.com/logout` |
+|`clientHost` (optional)|`string`|The origin of the client app obtained using `window.origin`|The hostname of the client app.  eg: `https://contoso.com`|
 |`clientSecret` (optional)|`string`|""|The client secret of the OIDC application|
 |`enablePKCE` (optional)|`boolean`|`true`|Specifies if a PKCE should be sent with the request for the authorization code. |
 |`prompt` (optional)|`string`|""|Specifies the prompt type of an OIDC request|
 |`responseMode` (optional)|`string`|`"query"`| Specifies the response mode. The value can either be `query` or `form_post`|
 |`scope` (optional)|`string[]`|`["openid"]`|Specifies the requested scopes|
-|`serverOrigin`|`string`|""|The origin of the Identity Provider. eg: `https://www.asgardio.io`|
 |[`storage`](#storage) (optional)| `"sessionStorage"`, `"webWorker"`, `"localStorage"`|`"sessionStorage"`| The storage medium where the session information such as the access token should be stored.|
 |`baseUrls` (required if the `storage` is set to `webWorker`|`string[]`|""|The URLs of the API endpoints. This is needed only if the storage method is set to `webWorker`. When API calls are made through the [`httpRequest`](#httprequest) or the [`httpRequestAll`](#httprequestall) method, only the calls to the endpoints specified in the `baseURL` attribute will be allowed. Everything else will be denied.|
 |`endpoints` (optional)|[`ServiceResourceTypes`](#serviceresourcetypes)|[ServiceResource Default Values](#serviceresourcetypes)| The OIDC endpoint URLs. The SDK will try to obtain the endpoint URLS using the `.well-known` endpoint. If this fails, the SDK will use these endpoint URLs. If this attribute is not set, then the default endpoint URLs will be used.|

--- a/packages/oidc-js/src/client.ts
+++ b/packages/oidc-js/src/client.ts
@@ -119,6 +119,10 @@ export class IdentityClient {
      * @return {Promise<boolean>} Resolves to true if initialization is successful.
      */
     public initialize(config: ConfigInterface | WebWorkerConfigInterface): Promise<boolean> {
+        if (!config.signOutRedirectURL) {
+            config.signOutRedirectURL = config.signInRedirectURL;
+        }
+
         this._storage = config.storage ?? Storage.SessionStorage;
         this._initialized = false;
         this._startedInitialize = true;

--- a/packages/oidc-js/src/client.ts
+++ b/packages/oidc-js/src/client.ts
@@ -62,6 +62,7 @@ import { WebWorkerClient } from "./worker";
  */
 const DefaultConfig = {
     authorizationType: AUTHORIZATION_CODE_TYPE,
+    clientHost: origin,
     clientSecret: null,
     consentDenied: false,
     enablePKCE: true,
@@ -85,7 +86,7 @@ export class IdentityClient {
     private _initialized: boolean;
     private _startedInitialize: boolean = false;
     private _onSignInCallback: (response: UserInfo) => void;
-    private _onSignOutCallback: (response: any) => void;
+    private _onSignOutCallback: () => void;
     private _onEndUserSession: (response: any) => void;
     private _onInitialize: (response: boolean) => void;
     private _onCustomGrant: Map<string, (response: any) => void> = new Map();
@@ -416,7 +417,7 @@ export class IdentityClient {
                 case Hooks.SignOut:
                     this._onSignOutCallback = callback;
                     if (isLoggedOut()) {
-                        callback();
+                        this._onSignOutCallback();
                     }
                     break;
                 case Hooks.EndUserSession:

--- a/packages/oidc-js/src/models/client.ts
+++ b/packages/oidc-js/src/models/client.ts
@@ -24,8 +24,8 @@ import { ResponseMode, Storage } from "../constants";
 interface BaseConfigInterface {
     authorizationType?: string;
     signInRedirectURL: string;
-    signOutRedirectURL: string;
-    clientHost: string;
+    signOutRedirectURL?: string;
+    clientHost?: string;
     clientID: string;
     clientSecret?: string;
     consentDenied?: boolean;

--- a/samples/using-oidc-js-sdk/react-js-app/src/index.tsx
+++ b/samples/using-oidc-js-sdk/react-js-app/src/index.tsx
@@ -30,9 +30,7 @@ const clientHost = origin;
 // Initialize the client
 auth.initialize({
     baseUrls: [serverOrigin],
-    clientHost: clientHost,
     clientID: "client-id",
-    enablePKCE: true,
     serverOrigin: serverOrigin,
     signInRedirectURL: clientHost + "/sign-in",
     signOutRedirectURL: clientHost + "/dashboard",


### PR DESCRIPTION
## Purpose
> Resolves #61 

## Changes introduced by this PR
- `clientHost` is made optional and the default value is set to `origin`.
- `signOutRedircetURL` is made optional and the `signInRedirectURL` is set as the default value.