### PR TITLE
Add capability to pass custom params in authorize request

### DIFF
--- a/packages/oidc-js/src/models/client.ts
+++ b/packages/oidc-js/src/models/client.ts
@@ -38,7 +38,7 @@ interface BaseConfigInterface {
     authorizationCode?: string;
     sessionState?: string;
     validateIDToken?: boolean;
-    customParams?: Map<string, string>;
+    customParams?: CustomParamsInterface;
 }
 /**
  * SDK Client config parameters.
@@ -64,4 +64,8 @@ export interface HttpClient {
 
 export interface WebWorkerClientConfigInterface extends WebWorkerConfigInterface {
     httpClient: HttpClient;
+}
+
+interface CustomParamsInterface {
+    [ key: string ]: string
 }

--- a/packages/oidc-js/src/models/client.ts
+++ b/packages/oidc-js/src/models/client.ts
@@ -38,6 +38,7 @@ interface BaseConfigInterface {
     authorizationCode?: string;
     sessionState?: string;
     validateIDToken?: boolean;
+    customParams?: Map<string, string>;
 }
 /**
  * SDK Client config parameters.

--- a/packages/oidc-js/src/utils/sign-in.ts
+++ b/packages/oidc-js/src/utils/sign-in.ts
@@ -174,9 +174,11 @@ export function sendAuthorizationRequest(
 
     const customParams = requestParams.customParams;
     if (customParams) {
-        customParams.forEach((value: string, key: string) => {
-            authorizeRequest += "&" + key + "=" + value;
-        });
+        for (const [ key, value ] of Object.entries(customParams)) {
+            if (key != "" && value != "") {
+                authorizeRequest += "&" + key + "=" + value;
+            }
+        }
     }
 
     if (requestParams.storage === Storage.WebWorker) {

--- a/packages/oidc-js/src/utils/sign-in.ts
+++ b/packages/oidc-js/src/utils/sign-in.ts
@@ -172,6 +172,13 @@ export function sendAuthorizationRequest(
         authorizeRequest += "&fidp=" + fidp;
     }
 
+    const customParams = requestParams.customParams;
+    if (customParams) {
+        customParams.forEach((value: string, key: string) => {
+            authorizeRequest += "&" + key + "=" + value;
+        });
+    }
+
     if (requestParams.storage === Storage.WebWorker) {
         return Promise.resolve({
             code: authorizeRequest,


### PR DESCRIPTION
## Purpose
> The application has to pass some custom parameters to the authorization request. This is to pass any extra non-specification parameters expected by the IDP


