### PR TITLE
Add leeway for id_tokens

### DIFF
--- a/packages/oidc-js/README.md
+++ b/packages/oidc-js/README.md
@@ -221,6 +221,7 @@ This method takes a `config` object as the only argument. The attributes of the 
 |`authorizationCode` (optional)| `string`|""|When the `responseMode` is set to `from_post`, the authorization code is returned as a `POST` request. Apps can use this attribute to pass the obtained authorization code to the SDK. Since client applications can't handle `POST` requests, the application's backend should implement the logic to receive the authorization code and send it back to the SDK.|
 | `sessionState` (optional) | `string`|""| When the `responseMode` is set to `from_post`, the session state is returned as a `POST` request. Apps can use this attribute to pass the obtained session state to the SDK. Since client applications can't handle `POST` requests, the application's backend should implement the logic to receive the session state and send it back to the SDK.|
 |`validateIDToken`(optional)|`boolean`|`true`|Allows you to enable/disable JWT ID token validation after obtaining the ID token.|
+|`clockTolerance`(optional)|`number`|`60`|Allows you to configure the leeway when validating the id_token.|
 
 The `initialize` hook is used to fire a callback function after initializing is successful. Check the [on()](#on) section for more information.
 

--- a/packages/oidc-js/src/client.ts
+++ b/packages/oidc-js/src/client.ts
@@ -62,6 +62,7 @@ const DefaultConfig = {
     authorizationType: AUTHORIZATION_CODE_TYPE,
     clientHost: origin,
     clientSecret: null,
+    clockTolerance: 60,
     consentDenied: false,
     enablePKCE: true,
     responseMode: null,

--- a/packages/oidc-js/src/models/client.ts
+++ b/packages/oidc-js/src/models/client.ts
@@ -39,7 +39,12 @@ interface BaseConfigInterface {
     sessionState?: string;
     validateIDToken?: boolean;
     customParams?: CustomParamsInterface;
+    /**
+     * Allowed leeway for id_tokens (in seconds).
+     */
+    clockTolerance?: number;
 }
+
 /**
  * SDK Client config parameters.
  */

--- a/packages/oidc-js/src/utils/crypto.ts
+++ b/packages/oidc-js/src/utils/crypto.ts
@@ -102,6 +102,8 @@ export const getJWKForTheIdToken = (jwtHeader: string, keys: JWKInterface[]): Pr
  * @param jwk public key used for signing.
  * @param {string} clientID app identification.
  * @param {string} issuer id_token issuer.
+ * @param {string} username Username.
+ * @param {number} clockTolerance - Allowed leeway for id_tokens (in seconds).
  * @returns {Promise<boolean>} whether the id_token is valid.
  */
 export const isValidIdToken = (
@@ -109,11 +111,13 @@ export const isValidIdToken = (
     jwk: KeyLike,
     clientID: string,
     issuer: string,
-    username: string
+    username: string,
+    clockTolerance: number
 ): Promise<boolean> => {
     return jwtVerify(idToken, jwk, {
         algorithms: getSupportedSignatureAlgorithms(),
         audience: clientID,
+        clockTolerance: clockTolerance,
         issuer: issuer,
         subject: username
     }).then(() => {

--- a/packages/oidc-js/src/utils/sign-in.ts
+++ b/packages/oidc-js/src/utils/sign-in.ts
@@ -235,7 +235,8 @@ export function validateIdToken(
                         jwk,
                         requestParams.clientID,
                         issuer,
-                        getAuthenticatedUser(idToken).username
+                        getAuthenticatedUser(idToken).username,
+                        requestParams.clockTolerance
                     );
                 })
                 .catch((error) => {


### PR DESCRIPTION
## Purpose
When validating the token, it checks the [nbf claim](https://tools.ietf.org/html/rfc7519#section-4.1.5) value to the second, hence if there is a discrepancy between the client's system time and the server time, the validation will fail resulting in the app being unresponsive (white screen).

## Goals
This PR adds an option to config the leeway in seconds (default 60s).

## Approach
Used the [`clockTolerance`](https://github.com/panva/jose/blob/ee6d7251036c4e778887cde61ba7db1e60cb5b8c/docs/interfaces/_types_d_.jwtclaimverificationoptions.md#clocktolerance) option in Jose to add the leeway.
