### PR TITLE
Allow developers to create multiple instances of `IdentityClient`

### DIFF
--- a/packages/oidc-js/README.md
+++ b/packages/oidc-js/README.md
@@ -59,7 +59,7 @@ var auth = AsgardioAuth.IdentityClient.getInstance();
 ## Getting Started
 ### Using Embedded Scripts
 ```javascript
-// This client is a singleton and can be instantiated as follows.
+// This client is a class and can be instantiated as follows.
 var auth = AsgardioAuth.IdentityClient.getInstance();
 
 // Once instantiated, the  client can be initialized by passing the relevant parameters such as the server origin, redirect URL, client ID, etc.
@@ -86,7 +86,7 @@ auth.on("sign-in", (response) => {
 // The SDK provides a client that can be used to carry out the authentication.
 import { IdentityClient } from "@asgardio/oidc-js";
 
-// This client is a singleton and can be instantiated as follows.
+// This client is a class and can be instantiated as follows.
 const auth = IdentityClient.getInstance();
 
 // Once instantiated, the  client can be initialized by passing the relevant parameters such as the server origin, redirect URL, client ID, etc.
@@ -186,15 +186,22 @@ import { IdentityClient } from "@asgardio/oidc-js/polyfilled/umd";
 
 ### getInstance
 ```typescript
-getInstance(): IdentityClient;
+getInstance(id?: string): IdentityClient;
 ```
 
-This returns an instance of the `IdentityClient`. Since the `IdentityClient` is a singleton, this method returns the same instance no matter how many times it is called.
+This returns a static instance of the `IdentityClient`. The SDK allows you to create multiple instances of the `IdentityClient`. To do so, you can pass an `id` into the `getInstance` method. If no instance has been created for the provided `id`, a new instance will be created and returned by this method. If an instance exists, then that instance will be returned. If no `id` is provided, the default instance will be returned. This allows the SDK to talk to multiple identity servers through the same app.
 
-This allows the developers the flexibility of using multiple files to implement the authentication logic. That is, you can have the sign in logic implemented on one page and the sign out logic on another.
+Creating a static instance affords the developers the flexibility of using multiple files to implement the authentication logic. That is, you can have the sign in logic implemented on one page and the sign out logic on another.
+
 ```javascript
 const auth = IdentityClient.getInstance();
 ```
+To create another instance,
+
+```javascript
+const auth2 = IdentityClient.getInstance("primary");
+```
+
 ### initialize
 ```typescript
 initialize(config);

--- a/packages/oidc-js/src/client.ts
+++ b/packages/oidc-js/src/client.ts
@@ -71,6 +71,8 @@ const DefaultConfig = {
     validateIDToken: true
 };
 
+const PRIMARY_INSTANCE = "primaryInstance";
+
 /**
  * IdentityClient class constructor.
  *
@@ -80,7 +82,7 @@ const DefaultConfig = {
  */
 export class IdentityClient {
     private _authConfig: ConfigInterface;
-    private static _instance: IdentityClient;
+    private static _instances: Map<string, IdentityClient> = new Map<string, IdentityClient>();
     private _client: WebWorkerClientInterface;
     private _storage: Storage;
     private _initialized: boolean;
@@ -115,14 +117,22 @@ export class IdentityClient {
      *
      * @preserve
      */
-    public static getInstance(): IdentityClient {
-        if (this._instance) {
-            return this._instance;
+    public static getInstance(id?: string): IdentityClient {
+        if (id && this._instances?.get(id)) {
+            return this._instances.get(id);
+        } else if (!id && this._instances?.get(PRIMARY_INSTANCE)) {
+            return this._instances.get(PRIMARY_INSTANCE);
         }
 
-        this._instance = new IdentityClient();
+        if (id) {
+            this._instances.set(id, new IdentityClient());
 
-        return this._instance;
+            return this._instances.get(id);
+        }
+
+        this._instances.set(PRIMARY_INSTANCE, new IdentityClient());
+
+        return this._instances.get(PRIMARY_INSTANCE);
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Resolves #73 

## Solution
The `getInstance()` method now accepts an id against which an instance of the `IdentityClient` class is stored. If no id is provided, an instance is stored against the default id. So, whenever the `getInstance()` method is called with a certain id, the relevant instance is returned. 

Example 
```javascript
const auth = IdentityClient.getInstance();
const auth2 = IdentityClient.getInstance("secondary");
```

