### PR TITLE
Remove default client host

### DIFF
--- a/lib/src/authentication-client.ts
+++ b/lib/src/authentication-client.ts
@@ -40,7 +40,6 @@ import {
  * Default configurations.
  */
 const DefaultConfig: Partial<AuthClientConfig<unknown>> = {
-    clientHost: origin,
     clockTolerance: 300,
     enablePKCE: true,
     responseMode: ResponseMode.query,


### PR DESCRIPTION
## Purpose
> The default client host was originally set to `origin` which resulted in errors in non-browser environments. This has now been removed. 
