### PR TITLE
Add config to prevent auto logout on token refresh errors

### DIFF
--- a/lib/src/client.ts
+++ b/lib/src/client.ts
@@ -43,6 +43,7 @@ import {
  * Default configurations.
  */
 const DefaultConfig: Partial<AuthClientConfig<unknown>> = {
+    autoLogoutOnTokenError: true,
     clockTolerance: 300,
     enablePKCE: true,
     responseMode: ResponseMode.query,

--- a/lib/src/models/client-config.ts
+++ b/lib/src/models/client-config.ts
@@ -20,6 +20,7 @@ import { OIDCEndpoints } from "./oidc-provider-meta-data";
 import { ResponseMode } from "../constants";
 
 export interface DefaultAuthClientConfig {
+  autoLogoutOnTokenError?: boolean;
   signInRedirectURL: string;
   signOutRedirectURL?: string;
   clientHost?: string;


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This will introduce a new config name `autoLogoutOnTokenError` which is set to `true` by default maintaining the default behaviour. When this is set to `false`, the SDK will not automatically signout the user upon encountering a token refresh error

### Related Issues
- 

### Related PRs
- 

### Checklist
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
